### PR TITLE
Upgrade marked to a secure version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "marked": "0.3.9",
+    "marked": "0.3.18",
     "readline": "1.3.0"
   },
   "keywords": [


### PR DESCRIPTION
> [WS-2019-0027]
>
> **Vulnerable versions:** < 0.3.18
> **Patched version:** 0.3.18
>
> Versions 0.3.17 and earlier of marked has Four regexes were vulnerable
> to catastrophic backtracking. This leaves markdown servers open to a
> potential REDOS attack.

[WS-2019-0027]: https://github.com/markedjs/marked/commit/b15e42b67cec9ded8505e9d68bb8741ad7a9590d