### PR TITLE
Update to jshint 2.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "coveralls": "3.0.0",
     "istanbul": "0.4.5",
-    "jshint": "2.9.4",
+    "jshint": "2.13.0",
     "mocha": "8.3.0",
     "mocha-lcov-reporter": "1.3.0"
   },


### PR DESCRIPTION
This addresses security vulnerabilities present in lodash, which is a
dependency of jshint:

* <https://npmjs.com/advisories/577>
* <https://npmjs.com/advisories/782>
* <https://npmjs.com/advisories/1065>
* <https://npmjs.com/advisories/1523>
* <https://npmjs.com/advisories/1673>