### PR TITLE
Add a test to check for GFM task list support

### DIFF
--- a/test/task-list.js
+++ b/test/task-list.js
@@ -1,0 +1,19 @@
+var codedown = require('../lib/codedown.js');
+var assert = require('assert');
+
+describe('task list', function(){
+  it('should not leak brackets', function (done) {
+    var input =
+      [
+        "* [X] checked",
+        "* [ ] unchecked",
+        "",
+        "```lang",
+        "code",
+        "```",
+      ].join('\n');
+    var output = codedown(input, "lang");
+    assert.equal(output, 'code');
+    done();
+  });
+});


### PR DESCRIPTION
This adds a test to make sure that square brackets from GFM task lists
are not included in the output.

Fixes #8