### PR TITLE
Trigger CI on pull_request_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   build:


### PR DESCRIPTION
This enables Coveralls for PR builds, which require access to the COVERALLS_REPO_TOKEN secret.